### PR TITLE
fix for pickle5 protocol with older Python versions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 gunicorn = "*"
 pandas = "*"
 Flask = "*"
+pickle5 = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d363d19231351941f137163ecac22947b9c1c040f187d75f0f5f210e4e5c1a43"
+            "sha256": "d36136d65f18ace37d439be21cb31719143b5f5c1909348290ebb4381cc1901f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -164,6 +164,13 @@
             ],
             "index": "pypi",
             "version": "==1.2.3"
+        },
+        "pickle5": {
+            "hashes": [
+                "sha256:7e013be68ba7dde1de5a8dbcc241f201dab1126e326715916ce4a26c27919ffc"
+            ],
+            "index": "pypi",
+            "version": "==0.0.11"
         },
         "python-dateutil": {
             "hashes": [

--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@ import logging
 from os import listdir, path
 import random
 
+import pickle5 as pickle
+
 from flask import Flask, render_template
 import pandas as pd
 
@@ -17,7 +19,8 @@ image_dir = "https://storage.googleapis.com/wine-flask/labels_on_bottle/"
 def main():
 	logging.info("Starting request in main()")
 	dataset_path = path.join(dataset_dir, "fake_name_desc_price.pkl")
-	dataset = pd.read_pickle(dataset_path)
+	with open(dataset_path,  "rb") as f:
+		dataset = pickle.load(f)
 	wine_ix = random.randint(0,len(dataset))
 	wine_name = dataset.iloc[wine_ix,:]['name']
 	wine_description = dataset.iloc[wine_ix,:]['description']

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ jinja2==2.11.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2
 markupsafe==1.1.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 numpy==1.20.2; python_version >= '3.7'
 pandas==1.2.3
+pickle5==0.0.11
 python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pytz==2021.1
 six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'


### PR DESCRIPTION
The newest Pandas pickle call in Python 3.8+ uses protocol=5 which does not seem to be natively compatible with older Python versions, such as my web service at the moment. 

This switches to explicitly importing pickle5 library before loading with the file through this rather than Pandas.